### PR TITLE
Fixed Search Not Ignoring Case

### DIFF
--- a/ServerAPI/Pages/Search.razor
+++ b/ServerAPI/Pages/Search.razor
@@ -27,7 +27,7 @@ else
     @foreach (var record in records)
     {
 
-        if (record.Name.Contains(OurPathParam, StringComparison.OrdinalIgnoreCase))
+        if (record.Name.Contains(OurPathParam, comparisonType: StringComparison.OrdinalIgnoreCase))
         {      
             <h4 class="name">@record.Name</h4>
             <br />


### PR DESCRIPTION
Search was not ignoring case properly. Added something that seemingly fixed the issue.